### PR TITLE
feat: Add Polygon Amoy (80002) to supported chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,14 +198,15 @@ The service includes an automated indexing system that syncs the ERC-8004 agent 
 
 - **Cron Schedule**: Runs every 15 minutes by default (configurable via D1)
 - **Queue-Based**: Uses Cloudflare Queues to handle indexing operations asynchronously
-- **Multi-Chain**: Supports indexing multiple chains (default: Sepolia and Base Sepolia)
+- **Multi-Chain**: Supports indexing multiple chains (default: Sepolia, Base Sepolia, and Polygon Amoy)
 - **State Management**: Tracks sync state in D1 database to enable incremental updates
 - **Concurrent Sync Protection**: Prevents multiple syncs for the same chain using lock mechanism
 
 ### Configuration
 
 Indexing configuration is stored in the D1 database (`indexing_config` table):
-- `chains`: JSON array of chain IDs to index (e.g., `["11155111", "84532"]`)
+- `chains`: JSON array of chain IDs to index (e.g., `["11155111", "84532", "80002"]`)
+  - Default: Ethereum Sepolia (11155111), Base Sepolia (84532), Polygon Amoy (80002)
 - `cron_interval`: Cron expression for sync frequency (default: `"*/15 * * * *"`)
 
 ### Sync Logs

--- a/migrations/0001_initial.sql
+++ b/migrations/0001_initial.sql
@@ -18,6 +18,6 @@ CREATE TABLE IF NOT EXISTS indexing_config (
 
 -- Insert default configuration values
 INSERT OR IGNORE INTO indexing_config (key, value) VALUES 
-  ('chains', '["11155111", "84532"]'),
+  ('chains', '["11155111", "84532", "80002"]'),
   ('cron_interval', '"*/15 * * * *"');
 

--- a/worker/src/utils/config-store.ts
+++ b/worker/src/utils/config-store.ts
@@ -3,7 +3,7 @@ import type { D1Database } from '@cloudflare/workers-types';
 /**
  * Default configuration values
  */
-const DEFAULT_CHAINS = [11155111, 84532]; // Sepolia, Base Sepolia
+const DEFAULT_CHAINS = [11155111, 84532, 80002]; // Sepolia, Base Sepolia, Polygon Amoy
 const DEFAULT_CRON_INTERVAL = '*/15 * * * *'; // Every 15 minutes
 
 /**


### PR DESCRIPTION
- Update DEFAULT_CHAINS to include Polygon Amoy (80002)
- Update initial migration default chains configuration
- Update README to reflect three supported chains
- Updated remote D1 database via SQL query

The indexing service will now index agents from:
- Ethereum Sepolia (11155111)
- Base Sepolia (84532)
- Polygon Amoy (80002)